### PR TITLE
Update channel from private to public option

### DIFF
--- a/config/meetcleo.yml
+++ b/config/meetcleo.yml
@@ -140,4 +140,4 @@ data_science_engineers:
 
   github_team: "ds-eng"
 
-  channel: "#ds-eng-casual"
+  channel: "#ds-eng-reviews"


### PR DESCRIPTION
sealbot doesn't seem to work with private slack channels. 

Added a new channel and updated config accordingly 