### PR TITLE
Add Pricing & Lending devs

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -8,6 +8,7 @@ teams=(
   seal_team
   data_science_engineers
   security_alerts
+  pricing_and_lending
 )
 
 for team in ${teams[*]}; do

--- a/config/meetcleo.yml
+++ b/config/meetcleo.yml
@@ -141,3 +141,20 @@ data_science_engineers:
   github_team: "ds-eng"
 
   channel: "#squad-ds-eng-reviews"
+
+pricing_and_lending:
+  exclude_titles:
+    - "WIP"
+
+  exclude_labels:
+    - "Do Not Merge"
+
+  use_labels: true
+
+  include_repos:
+    - meetcleo
+
+  github_team: "ds-payments-and-lending-be"
+
+  channel: "#squad-pricing_and_lending-devs"
+


### PR DESCRIPTION
Add configuration for Pricing & Lending devs. Yes, the naming right now is a bit confusing: `pricing_and_lending`, `ds-payments-and-lending`. We are changing names with the change of term, some bits have already been renamed, but we are not 100% sure of what the final name will be, so we are holding off renaming Github team names.