### PR TITLE
Rename Pricing & Lending to EWA Modelling

### DIFF
--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -2,7 +2,7 @@
 
 teams=(
   ewa_core
-  plus_subscription
+  ewa_progression
 )
 
 for team in ${teams[*]} ; do

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -5,12 +5,12 @@ teams=(
   payments_infrastructure
   data
   ewa_core
-  pricing_and_lending
+  ewa_modelling
   seal_team
   security_alerts_web_and_be
   security_alerts_app
   card_2
-  plus_subscription
+  ewa_progression
   ufu
   marketplace
 )

--- a/config/meetcleo.yml
+++ b/config/meetcleo.yml
@@ -160,7 +160,7 @@ ewa_core:
   github_team: "ewa-core"
   channel: "#squad-ewa_core-devs"
 
-pricing_and_lending:
+ewa_modelling:
   exclude_titles: []
   exclude_labels:
     - "Do Not Merge"
@@ -175,8 +175,8 @@ pricing_and_lending:
     - cleo-flux
     - general-infra
 
-  github_team: "pricing-and-lending"
-  channel: "#squad-pricing_and_lending-devs"
+  github_team: "ewa-modelling"
+  channel: "#squad-ewa_modelling-devs"
 
 card_2:
   exclude_titles:


### PR DESCRIPTION
Also, fix old config references that point to `plus_subscription` to `ewa_progression`.