### PR TITLE
Stop sending Card2 seal webhooks

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -7,7 +7,6 @@ teams=(
   seal_team
   security_alerts_web_and_be
   security_alerts_app
-  card_2
   tx_enrichment
   marketplace
 )

--- a/config/meetcleo.yml
+++ b/config/meetcleo.yml
@@ -181,26 +181,6 @@ ewa_modelling:
   github_team: "ewa-modelling"
   channel: "#squad-ewa_modelling-devs"
 
-card_2:
-  exclude_titles:
-    - "WIP"
-    - "[WIP]"
-    - "DO NOT MERGE"
-    - "[DO NOT MERGE]"
-
-  exclude_labels:
-    - "Do Not Merge"
-
-  use_labels: true
-
-  include_repos:
-    - meetcleo
-    - mobile-app
-
-  github_team: "card-2"
-
-  channel: "#squad-honet_badgers-devs"
-
 tx_enrichment:
   exclude_titles:
     - "WIP"


### PR DESCRIPTION
We want to stop seeing Seal notifications, as they've been replaced by Swarmia
👋 🦭 